### PR TITLE
Adds option not to run indefinitely.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grunt-connect
 
-Run a connect server, indefinitely. The built in Grunt server task is terrific for the great majority of cases, however sometimes you just want to ability to run a web server on a local file system and interact with the files using a web browser.
+Run a connect server. The built in Grunt server task is terrific for the great majority of cases, however sometimes you just want to ability to run a web server on a local file system and interact with the files using a web browser. For that reason, grunt-connect's default behaviour is to run indefinitely.
 
 ## Getting Started
 Install this grunt plugin next to your project's [grunt.js gruntfile][getting_started] with: `npm install grunt-connect`
@@ -33,12 +33,17 @@ grunt.initConfig({
       port: 1337,
       base: 'example'
     },
-    meta: {
+    test: {
       port: 1338,
+      base: 'test',
+      runIndefinitely: false
+    },
+    meta: {
+      port: 1339,
       base: 'tasks'
     },
     combined: {
-      port: 1339,
+      port: 1340,
       combine: [
         'example',
         'tasks'

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ grunt.initConfig({
     test: {
       port: 1338,
       base: 'test',
-      runIndefinitely: false
+      keepAlive: false
     },
     meta: {
       port: 1339,

--- a/grunt.js
+++ b/grunt.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
       meta: {
         port: 1338,
         base: 'tasks',
-        runIndefinitely: false
+        keepAlive: false
       },
       combined: {
         port: 1339,

--- a/grunt.js
+++ b/grunt.js
@@ -35,7 +35,8 @@ module.exports = function(grunt) {
       },
       meta: {
         port: 1338,
-        base: 'tasks'
+        base: 'tasks',
+        runIndefinitely: false
       },
       combined: {
         port: 1339,

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -20,8 +20,12 @@ module.exports = function(grunt) {
   // ==========================================================================
 
   grunt.registerMultiTask('connect', 'Run a simple static connect server till you shut it down.', function() {
-    // Don't ever close this task!
-    this.async();
+
+    var runIndefinitely = this.data.runIndefinitely;
+
+    if (runIndefinitely === undefined || runIndefinitely == true) {
+      this.async();
+    }
 
     var port = this.data.port || 1337;
     var bases = [];

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -21,9 +21,9 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('connect', 'Run a simple static connect server till you shut it down.', function() {
 
-    var runIndefinitely = this.data.runIndefinitely;
+    var keepAlive = this.data.keepAlive;
 
-    if (runIndefinitely === undefined || runIndefinitely == true) {
+    if (keepAlive === undefined || keepAlive === true) {
       this.async();
     }
 


### PR DESCRIPTION
Hello,

I've added an option not to run indefinitely. The use case, which is temporary considering the grunt 0.4.0 release (where this behaviour can be achieved by the contrib-server task), is to run different servers (like for tests) on different ports.

Defaults to run indefinitely, but can be changed as shown in the readme.
